### PR TITLE
Fix utils import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for Futbol Liga."""


### PR DESCRIPTION
## Summary
- make `utils` a proper Python package so tests can import
- ensure tests can import modules by adjusting `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf955adc4832a81414ed55bc3681e